### PR TITLE
The Today shortcut was broken because of a stray href. Now fixed

### DIFF
--- a/src/datetime-picker.component.ts
+++ b/src/datetime-picker.component.ts
@@ -95,7 +95,7 @@ declare var moment: any;
     </div>
 
     <div class="shortcuts" *ngIf="showTodayShortcut">
-      <a href="#" (click)="selectToday()">Today</a>
+      <a (click)="selectToday()">Today</a>
     </div>
 
     <!-- Hour Minute -->


### PR DESCRIPTION
I left this embarrassing bug in my last pull request. Mind including this fix in a new release?

Manne